### PR TITLE
Mark compare as noexcept to avoid error

### DIFF
--- a/pyLZJD/lzjd_cython.pyx
+++ b/pyLZJD/lzjd_cython.pyx
@@ -489,7 +489,7 @@ cdef int q_partition(int[:] arr, int left, int right):
 @cython.wraparound(False)   # Deactivate negative indexing.
 @cython.initializedcheck(False)
 @cython.cdivision(True)
-cdef int compare(const_void *va, const_void *vb):
+cdef int compare(const_void *va, const_void *vb) noexcept:
     cdef int a = (<signed int *>va)[0]
     cdef int b = (<signed int *>vb)[0]
     return (a > b) - (a < b)


### PR DESCRIPTION
Without this patch, I get the following error:

```
Error compiling Cython file:
------------------------------------------------------------
...
@cython.wraparound(False)   # Deactivate negative indexing.
@cython.initializedcheck(False)
@cython.cdivision(True)
@cython.exceptval(check=False)
cdef void sort(signed int* y, ssize_t l) noexcept:
    qsort(y, l, cython.sizeof(int), compare)
                                    ^
------------------------------------------------------------

/home/eschwartz/.local/lib/python3.6/site-packages/pyLZJD/lzjd_cython.pyx:434:36: Cannot assign type 'int (const_void *, const_void *) except? -1' to 'int (*)(const_void *, const_void *) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to type 'int (const_void *, const_void *) except? -1'.
```