### PR TITLE
Fixed similarity formula

### DIFF
--- a/pyLZJD/lzjd.py
+++ b/pyLZJD/lzjd.py
@@ -67,9 +67,9 @@ def sim(A, B):
     #What if the hashes are different sizes? Math works out that we can take the min length
     #Reduces as back to same size hashes, and its as if we only computed the min-hashing to
     #*just* as many hashes as there were members
-    min_len = min(A.shape[0], B.shape[0])
-    
-    return intersection_size/float(2*min_len - intersection_size)
+    total_size = A.shape[0] + B.shape[0] - intersection_size
+
+    return intersection_size/float(total_size)
 
 def vectorize(b, hash_size=1024, k=8, processes=-1, false_seen_prob=0.0, seed=None):
     if isinstance(b, list): #Assume this is a list of things to hash. 


### PR DESCRIPTION
I ran into the issue described [here](https://github.com/EdwardRaff/pyLZJD/issues/8)

@edmcman stated he found a workaround that worked for him, but the workaround was not posted.

This might be it, as it yields a result closer to what is expected (it would previously always return 1.0, which is incorrect).

```
import pyLZJD

data1 = b"Hello, this is some example data!"
data2 = b"Hello, this is some other example data!"

hash1 = pyLZJD.digest(data1)
hash2 = pyLZJD.digest(data2)

similarity = pyLZJD.sim(hash1, hash2)

print("Similarity:", similarity)
```

Result:
`Similarity: 0.88`

Lastly, my PR relies on a fix described in [this PR](https://github.com/EdwardRaff/pyLZJD/pull/7), which should probably be merged into master.